### PR TITLE
Add disappearing messages feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Here is the link to talkify App - https://talkify-54db0.web.app/
 
+## Features
+
+- **Disappearing Messages**: Chat messages are automatically removed 24 hours after they are sent or when the sender logs out.
+
 
 
 # Getting Started with Create React App

--- a/src/actions/auth.actions.js
+++ b/src/actions/auth.actions.js
@@ -1,5 +1,6 @@
 import firebase from "firebase";
 import { authConstant } from "./constants";
+import { deleteUserMessages } from "./user.actions";
 import { NavLink, Link, Redirect } from "react-router-dom";
 
 export const signup = (user) => {
@@ -302,6 +303,7 @@ export const logout = (username) => {
       .doc(username)
       .update({ isOnline: false, lastseen: d })
       .then(() => {
+        dispatch(deleteUserMessages(username));
         firebase
           .auth()
           .signOut()


### PR DESCRIPTION
## Summary
- automatically delete messages older than 24 hours when conversations update
- remove all of a user's messages from conversations on logout
- call new cleanup logic during logout
- document disappearing message behavior in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a77354f48333b45d4bfd57404061